### PR TITLE
fix: remove must exist

### DIFF
--- a/classes/entity/section.php
+++ b/classes/entity/section.php
@@ -26,7 +26,7 @@ class section {
     public static function get_section_by_ofd_id($ofdid) {
         global $DB;
 
-        return $DB->get_record('int_discipline_section', ['ofd_id' => $ofdid], '*', MUST_EXIST);
+        return $DB->get_record('int_discipline_section', ['ofd_id' => $ofdid], '*');
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$plugin->version = 2024032100;
+$plugin->version = 2024051700;
 $plugin->requires = 2022041200;
 $plugin->release = '1.0.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Mudanças prospostas

 - Esse fluxo está fazendo com que a função de criar displinas tenha problemas, pois ela verifica primeiro se a disciplina existe e depois faz a criação da mesma, o parametro MUST_EXIST está disparando exceção caso nao encontre o resgistro no banco. Por conta disso precisamos remover essa constante MUST_EXIST

Fiz vários outros testes com o o Harpia no PHP 8 e o plugin no moodle 4.3 atualizado e nao peguei mais erros além desse